### PR TITLE
ATP-1092 use valid http status code

### DIFF
--- a/src/ExceptionHandler.php
+++ b/src/ExceptionHandler.php
@@ -92,21 +92,26 @@ class ExceptionHandler extends BaseExceptionHandler
             ], 404);
         }
 
+        if (!$e instanceof FlattenException) {
+            $e = FlattenException::create($e);
+        }
+
         if (env('APP_DEBUG', false)) {
             return response()->json([
                 'errorMsg' => $e->getMessage(),
                 'stackTrace' => $e->getTrace()
-            ], $e->getCode());
-        }
-
-        if (!$e instanceof FlattenException) {
-            $e = FlattenException::create($e);
+            ], $e->getStatusCode());
         }
 
         switch ($e->getStatusCode()) {
             case 404:
                 $msg = 'Sorry, the page you are looking for could not be found.';
                 break;
+
+            case 405:
+                $msg = 'Sorry, this route does not exist.';
+                break;
+
             default:
                 $msg = 'Whoops, looks like something went wrong.';
         }

--- a/src/ExceptionHandler.php
+++ b/src/ExceptionHandler.php
@@ -105,11 +105,8 @@ class ExceptionHandler extends BaseExceptionHandler
 
         switch ($e->getStatusCode()) {
             case 404:
-                $msg = 'Sorry, the page you are looking for could not be found.';
-                break;
-
             case 405:
-                $msg = 'Sorry, this route does not exist.';
+                $msg = 'Sorry, the page you are looking for could not be found.';
                 break;
 
             default:

--- a/tests/ExceptionHandlerTest.php
+++ b/tests/ExceptionHandlerTest.php
@@ -86,6 +86,10 @@ class ExceptionHandlerTest extends TestCase
 
         $response = $this->handler->render(new Request(), new FailedJobException('failed job', 0));
 
+        $body = json_decode($response->getContent(), true);
+
+        $this->assertArrayNotHasKey('stackTrace', $body);
+
         $this->assertEquals('500', $response->getStatusCode());
     }
 
@@ -98,6 +102,10 @@ class ExceptionHandlerTest extends TestCase
         putenv('APP_DEBUG=' . true);
 
         $response = $this->handler->render(new Request(), new FailedJobException('failed job', 0));
+
+        $body = json_decode($response->getContent(), true);
+
+        $this->assertArrayHasKey('stackTrace', $body);
 
         $this->assertEquals('500', $response->getStatusCode());
     }

--- a/tests/ExceptionHandlerTest.php
+++ b/tests/ExceptionHandlerTest.php
@@ -84,7 +84,7 @@ class ExceptionHandlerTest extends TestCase
     {
         putenv('APP_DEBUG=' . false);
 
-        $response = $this->handler->render(new Request(), new FailedJobException('failed job', 400));
+        $response = $this->handler->render(new Request(), new FailedJobException('failed job', 0));
 
         $this->assertEquals('500', $response->getStatusCode());
     }
@@ -97,8 +97,8 @@ class ExceptionHandlerTest extends TestCase
     {
         putenv('APP_DEBUG=' . true);
 
-        $response = $this->handler->render(new Request(), new FailedJobException('failed job', 400));
+        $response = $this->handler->render(new Request(), new FailedJobException('failed job', 0));
 
-        $this->assertEquals('400', $response->getStatusCode());
+        $this->assertEquals('500', $response->getStatusCode());
     }
 }


### PR DESCRIPTION
Exception code could not be used as http status code. Valid status code need be used